### PR TITLE
Bugfix/allow setuppy to use cc package name

### DIFF
--- a/{{cookiecutter.repo_name}}/LICENSE
+++ b/{{cookiecutter.repo_name}}/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Cristian Matache
+Copyright (c) {% now 'utc', '%Y' %} {{cookiecutter.author_name}}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -3,7 +3,7 @@
 [//]: # "add-your-build-status-badge-here"
 
 [![powered_by_alpha_build](https://img.shields.io/badge/Powered%20by%20-AlphaBuild-lightblue?style=flat&logo=CMake&logoColor=lightblue)
-](https://github.com/cristianmatache/alpha-build)
+](https://github.com/alpha-build/alpha-build)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 ![pylint Score](https://mperlet.github.io/pybadge/badges/10.svg)

--- a/{{cookiecutter.repo_name}}/build-support/alpha-build/core/python/clean.mk
+++ b/{{cookiecutter.repo_name}}/build-support/alpha-build/core/python/clean.mk
@@ -1,5 +1,5 @@
 # !!! Don't edit this file !!!
-# This file is part of AlphaBuild core, don't edit it in a repo other than https://github.com/cristianmatache/alpha-build/
+# This file is part of AlphaBuild core, don't edit it in a repo other than https://github.com/alpha-build/alpha-build/
 # Please submit an issue/pull request to the main repo if you need any changes in the core infrastructure.
 # Before doing that, you may wish to consider:
 # - updating the config files in build-support/alpha-build/config/ to configure tools for your own use case

--- a/{{cookiecutter.repo_name}}/build-support/alpha-build/core/python/pythonpath.mk
+++ b/{{cookiecutter.repo_name}}/build-support/alpha-build/core/python/pythonpath.mk
@@ -1,5 +1,5 @@
 # !!! Don't edit this file !!!
-# This file is part of AlphaBuild core, don't edit it in a repo other than https://github.com/cristianmatache/alpha-build/
+# This file is part of AlphaBuild core, don't edit it in a repo other than https://github.com/alpha-build/alpha-build/
 # Please submit an issue/pull request to the main repo if you need any changes in the core infrastructure.
 # Before doing that, you may wish to consider:
 # - updating the config files in build-support/alpha-build/config/ to configure tools for your own use case

--- a/{{cookiecutter.repo_name}}/build-support/alpha-build/core/python/test.mk
+++ b/{{cookiecutter.repo_name}}/build-support/alpha-build/core/python/test.mk
@@ -1,5 +1,5 @@
 # !!! Don't edit this file !!!
-# This file is part of AlphaBuild core, don't edit it in a repo other than https://github.com/cristianmatache/alpha-build/
+# This file is part of AlphaBuild core, don't edit it in a repo other than https://github.com/alpha-build/alpha-build/
 # Please submit an issue/pull request to the main repo if you need any changes in the core infrastructure.
 # Before doing that, you may wish to consider:
 # - updating the config files in build-support/alpha-build/config/ to configure tools for your own use case

--- a/{{cookiecutter.repo_name}}/build-support/alpha-build/core/resolver.mk
+++ b/{{cookiecutter.repo_name}}/build-support/alpha-build/core/resolver.mk
@@ -1,5 +1,5 @@
 # !!! Don't edit this file !!!
-# This file is part of AlphaBuild core, don't edit it in a repo other than https://github.com/cristianmatache/alpha-build/
+# This file is part of AlphaBuild core, don't edit it in a repo other than https://github.com/alpha-build/alpha-build/
 # Please submit an issue/pull request to the main repo if you need any changes in the core infrastructure.
 # Before doing that, you may wish to consider:
 # - updating the config files in build-support/alpha-build/config/ to configure tools for your own use case

--- a/{{cookiecutter.repo_name}}/build-support/alpha-build/core/setup_lite_py.py
+++ b/{{cookiecutter.repo_name}}/build-support/alpha-build/core/setup_lite_py.py
@@ -14,7 +14,7 @@ setup(
     description="AlphaBuild's lightweight core",
     long_description=README.read_text(),
     long_description_content_type="text/markdown",
-    url="https://github.com/cristianmatache/alpha-build",
+    url="https://github.com/alpha-build/alpha-build",
     author="Cristian Matache",
     # author_email="",
     license="MIT",

--- a/{{cookiecutter.repo_name}}/build-support/git-bash-integration/setup.py
+++ b/{{cookiecutter.repo_name}}/build-support/git-bash-integration/setup.py
@@ -16,7 +16,7 @@ setup(
     description="AlphaBuild's utils for Git Bash on Windows",
     long_description=README.read_text(),
     long_description_content_type="text/markdown",
-    url="https://github.com/cristianmatache/alpha-build",
+    url="https://github.com/alpha-build/alpha-build",
     author="Cristian Matache",
     # author_email="",
     license="MIT",

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -15,7 +15,7 @@ def main() -> None:
         python_requires='>=3.7',
         install_requires=REQS_FILE.read_text(encoding='utf-8'),
         zip_safe=False,  # for mypy
-        package_data={'{self.lib_name}': ['py.typed']},  # expose types to users
+        package_data={'{{cookiecutter.package_name}}': ['py.typed']},  # expose types to users
         author='{{cookiecutter.author_name}}',
         author_email='{{cookiecutter.author_email}}',
         description='',


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.
The main aim of this PR is to allow setup.py to be generated correctly using the package name from cookie cutter - I believe the setup.py was using an old version of code that wasn't refactored to consider cookie cutters value.

I've also adjusted some of the references to the alpha-build project to come from the actual project rather than Cristians old personal repo.

I've also updated the LICENSE to take the current year and cookie cutter author name.

Fixes # (issue)

https://github.com/alpha-build/cookiecutter-alpha-build-polyrepo-py/issues/24 

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I used a clean venv with cookie cutter and ran `cookie cutter path/to/my/template' and checked the setup.py is generated. correctly as shown in below screenshot.

![image](https://github.com/alpha-build/cookiecutter-alpha-build-polyrepo-py/assets/32771508/d075e31a-3d0b-48ad-b18d-39c4aabe4a16)

Also verifying that LICENSE date is automatic and author name is from cookie cutter.

<img width="641" alt="image" src="https://github.com/alpha-build/cookiecutter-alpha-build-polyrepo-py/assets/32771508/77c87d97-8600-45ce-b617-6d8e99c5da82">


## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
